### PR TITLE
Switch release pipeline from ghr/goxz to GoReleaser

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- This template is a recommended format. Feel free to add, remove, or modify sections as needed. Remove any sections that are not applicable. -->
+<!-- Please remove the comments in this template when creating a PR. -->
+
+## Summary
+
+<!-- Briefly describe the purpose and background of this PR. -->
+
+## Changes
+
+<!-- Describe the specific changes made. -->
+
+## Related Information
+
+<!-- List any related issues, other PRs, documentation, or reference links. -->
+<!-- Linking to issues or other PRs is recommended, as it enables cross-referencing on GitHub and makes tracking easier. -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,34 @@
-# This workflow is triggered when a version tag (vX.X.X) is pushed to the repository.
-# Before triggering this workflow, ensure the VERSION in Makefile matches the tag version (without 'v' prefix).
-# The workflow automatically checks version consistency and fails if they don't match.
 name: release
-permissions: write-all
+
 on:
   push:
     tags:
-      - 'v*.*.*'
+      # Triggered by pushing a version tag, e.g. git tag v0.0.8 && git push origin v0.0.8
+      - "v*"
+
+permissions:
+  contents: write
 
 jobs:
-  release:
+  goreleaser:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full git history is needed for GoReleaser to generate changelogs.
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Verify version consistency
-        run: |
-          # Extract tag version (remove 'v' prefix)
-          TAG_VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Tag version: $TAG_VERSION"
+          cache: true
 
-          # Extract version from Makefile
-          MAKEFILE_VERSION=$(grep '^VERSION := ' Makefile | cut -d' ' -f3)
-          echo "Makefile version: $MAKEFILE_VERSION"
-
-          # Check if versions match
-          if [ "$TAG_VERSION" != "$MAKEFILE_VERSION" ]; then
-            echo "Error: Tag version ($TAG_VERSION) does not match Makefile version ($MAKEFILE_VERSION)"
-            exit 1
-          fi
-
-          echo "Version check passed: $TAG_VERSION"
-      - run: make setup
-      - run: make build-dist
-      - name: Create GitHub release
-        run: |
-          # Extract full tag (e.g., v1.2.3)
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-
-          # Add go-tools/bin to PATH and create release using ghr
-          export PATH="$(pwd)/.dev/go-tools/bin:$PATH"
-          ghr -n "${TAG_NAME}" -b "Release ${TAG_NAME}" "${TAG_NAME}" .dev/build/dist
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,49 @@
+version: 2
+
+project_name: xs
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: xs
+    main: ./cmd/xs
+    binary: xs
+    env:
+      - CGO_ENABLED=0
+    targets:
+      - linux_amd64
+      - linux_arm64
+      - darwin_amd64
+      - darwin_arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/kohkimakimoto/xs/internal.Version={{.Version}}
+      - -X github.com/kohkimakimoto/xs/internal.CommitHash={{.ShortCommit}}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  disable: true
+
+release:
+  github:
+    owner: kohkimakimoto
+    name: xs
+  draft: false
+  # Automatically marks as prerelease if the tag contains a hyphen (e.g. v1.0.0-rc1).
+  prerelease: auto
+  # Overwrites the existing release if re-run for the same tag.
+  mode: replace

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,9 @@
 
 SHELL := bash
 PATH := $(CURDIR)/.dev/go-tools/bin:$(PATH)
-COMMIT_HASH := $(shell git rev-parse HEAD)
+COMMIT_HASH := $(shell git rev-parse --short HEAD)
 
-VERSION := 0.0.7
-BUILD_LDFLAGS = "-s -w -X github.com/kohkimakimoto/xs/internal.CommitHash=$(COMMIT_HASH) -X github.com/kohkimakimoto/xs/internal.Version=$(VERSION)"
+BUILD_LDFLAGS = "-s -w -X github.com/kohkimakimoto/xs/internal.CommitHash=$(COMMIT_HASH)"
 
 # Load .env file if it exists.
 ifneq (,$(wildcard ./.env))
@@ -29,8 +28,6 @@ setup: ## Setup development environment
 	@echo "==> Setting up development environment..."
 	@mkdir -p $(CURDIR)/.dev/go-tools
 	@export GOPATH=$(CURDIR)/.dev/go-tools && \
-		go install github.com/Songmu/goxz/cmd/goxz@latest && \
-		go install github.com/tcnksm/ghr@latest && \
 		go install github.com/axw/gocov/gocov@latest && \
 		go install github.com/matm/gocov-html/cmd/gocov-html@latest
 	@export GOPATH=$(CURDIR)/.dev/go-tools && go clean -modcache && rm -rf $(CURDIR)/.dev/go-tools/pkg
@@ -52,11 +49,6 @@ build: ## Build dev binary
 build-release: ## Build release binary
 	@mkdir -p .dev/build/release
 	@CGO_ENABLED=0 go build -ldflags=$(BUILD_LDFLAGS) -trimpath -o .dev/build/release/xs ./cmd/xs
-
-.PHONY: build-dist
-build-dist: ## Build cross-platform binaries for distribution
-	@mkdir -p .dev/build/dist
-	@CGO_ENABLED=0 goxz -n xs -os=linux,darwin -static -build-ldflags=$(BUILD_LDFLAGS) -trimpath -d=.dev/build/dist ./cmd/xs
 
 .PHONY: build-clean
 build-clean: ## Clean up build artifacts


### PR DESCRIPTION
## Summary

Migrate the release pipeline from the manual ghr/goxz-based process to GoReleaser. This centralizes version management on git tags and simplifies the release workflow.

## Changes

- Add `.goreleaser.yaml` with GoReleaser v2 configuration for linux/darwin (amd64/arm64)
- Replace the release workflow (`.github/workflows/release.yml`) with `goreleaser/goreleaser-action@v6`
- Remove `VERSION` variable and `build-dist` target from Makefile (GoReleaser handles versioning and cross-platform builds)
- Remove `goxz` and `ghr` installation from the setup target
- Use short commit hash in local build ldflags for consistency

🤖 Generated with [Claude Code](https://claude.ai/code)
