### PR TITLE
Add release version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # XS
 
 [![test](https://github.com/kohkimakimoto/xs/actions/workflows/test.yml/badge.svg)](https://github.com/kohkimakimoto/xs/actions/workflows/test.yml)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/kohkimakimoto/xs)](https://github.com/kohkimakimoto/xs/releases)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kohkimakimoto/xs/blob/main/LICENSE)
 
 XS is a SSH command wrapper that enhances your SSH operations.


### PR DESCRIPTION
## Summary

Add a GitHub release version badge to the README, displayed alongside the existing test and license badges.

## Changes

- Add `shields.io` release badge linking to the GitHub releases page

🤖 Generated with [Claude Code](https://claude.ai/code)
